### PR TITLE
Update utils file to show correct command without dash

### DIFF
--- a/src/lib/utils
+++ b/src/lib/utils
@@ -56,7 +56,7 @@ showRootCommandContent() {
 /_/   /_/\__,_/\__/\__/\___/_/      /____/ .___/\__, /
                                         /_/    /____/
     "
-    echo "Usage: flutter-spy <file>"
+    echo "Usage: flutterspy <file>"
     echo ""
     echo "Arguments:"
     echo "  file          The apk file to spy on"


### PR DESCRIPTION
Updated utils to remove dash between command as it does not match with the actual command. 